### PR TITLE
Added update 2 to config and manifest

### DIFF
--- a/SIFLess/SIFLess/App.config
+++ b/SIFLess/SIFLess/App.config
@@ -8,7 +8,7 @@
     <add key="SolrRequiredVersion" value="6.6.2"/>
     <add key="ConfigManifestPath" value="Data\ConfigurationManifest.xml" />
     <add key="Topologies" value="XM-CM|XM-CM-CD|XP0"/>
-    <add key="Versions" value="9.0 Initial Release|9.0 Update 1"/>
+    <add key="Versions" value="9.0 Initial Release|9.0 Update 1|9.0 Update 2"/>
   </appSettings>
   <unity configSource="Unity.config" />
   <sifless.validation configSource="Sifless.Validation.config"/>

--- a/SIFLess/SIFLess/Data/ConfigurationManifest.xml
+++ b/SIFLess/SIFLess/Data/ConfigurationManifest.xml
@@ -909,4 +909,459 @@ $xConnectSiteName = '[XCONNECT_SITE]'
       </ScriptMap>
     </ScriptMaps>
   </Configuration>
+	<Configuration topology="XM-CM" version="9.0 Update 2" wrapper="PSTemplates\blank.ps1" scriptmaps="GLOBAL|INSTALL|UNINSTALL">
+    <File type="data" name="Sitecore 9.0.2 rev. 180604 (OnPrem)_cm.scwdp.zip" />
+    <File type="config" name="sitecore-solr.json">
+      <ScriptMaps>
+        <ScriptMap location="INSTALL">
+          <![CDATA[
+    $solrParams = @{
+    Path = "$PSScriptRoot\sitecore-solr.json"
+    SolrUrl = $SolrUrl
+    SolrRoot = $SolrRoot
+    SolrService = $SolrService
+    CorePrefix = $Prefix
+    }
+    Install-SitecoreConfiguration @solrParams
+        ]]>
+        </ScriptMap>
+        <ScriptMap location="UNINSTALL">
+          <![CDATA[
+    $solrParams = @{
+    Path = ".\remove-sitecore-solr-cores.json"
+    SolrUrl = $SolrUrl
+    SolrRoot = $SolrRoot
+    CorePrefix = $Prefix
+    }
+    try{
+	    Install-SitecoreConfiguration @solrParams
+    }
+    catch{
+	    $error = $_.Exception
+	
+	    #If we are failing because it has already been unloaded, then we can proceed
+	    if($error.Message.Contains("Cannot unload non-existent core")){
+		    Write-Warning -Message ("Core is not found. May have already been uninstalled. Proceeding to folders." | Out-String)
+	    }
+	    else{
+		    throw $error;
+	    }
+    }
+    #remove Sitecore Solr folders
+    $solrParams = @{
+    Path = ".\remove-sitecore-solr-folders.json"
+    SolrUrl = $SolrUrl
+    SolrRoot = $SolrRoot
+    CorePrefix = $Prefix
+    }
+    Install-SitecoreConfiguration @solrParams
+    ]]>
+        </ScriptMap>
+      </ScriptMaps>
+    </File>
+    <File type="config" name="sitecore-XM1-cm.json">
+      <FieldMaps>
+        <Field name="sitename" type="text" map="SITENAME" label="Site Name" description="The Name of the Website"/>
+      </FieldMaps>
+      <ScriptMaps>
+        <ScriptMap location="INSTALL">
+          <![CDATA[
+    $sitecoreParams = @{
+    Path = "$PSScriptRoot\sitecore-XM1-cm.json"
+    Package = "$PSScriptRoot\Sitecore 9.0.2 rev. 180604 (OnPrem)_cm.scwdp.zip"
+    LicenseFile = $LicenseFilePath
+    SqlDbPrefix = $Prefix
+    SolrCorePrefix = $Prefix
+    SolrUrl = $SolrUrl
+    SiteName = '[SITENAME]'
+    SqlServer = $SqlServer
+    SqlAdminPassword = $SqlAdminPassword
+    SqlAdminUser = $SqlAdminUser
+    }
+    Install-SitecoreConfiguration @sitecoreParams
+        ]]>
+        </ScriptMap>
+        <ScriptMap location="UNINSTALL">
+          <![CDATA[
+           
+     $sitecoreParams = @{
+        Path = ".\remove-sitecore-XM.json"
+        SqlDbPrefix = $Prefix
+        SiteName = '[SITENAME]'
+        SqlServer = $SqlServer
+        SqlAdminPassword = $SqlAdminPassword
+        SqlAdminUser = $SqlAdminUser
+        }
+        Install-SitecoreConfiguration @sitecoreParams
+          
+          ]]>
+        </ScriptMap>
+      </ScriptMaps>
+    </File>
+    <ScriptMaps>
+      <ScriptMap location="GLOBAL">
+        <![CDATA[
+$Prefix = '[PREFIX]'
+$PSScriptRoot = '[DATA_FOLDER]'
+$SolrUrl = '[SOLR_URL]'
+$SolrRoot = '[SOLR_ROOT]'
+$SolrService = '[SOLR_SERVICE]'
+$SqlServer = '[SQL_SERVER]'
+$SqlAdminUser = '[SQL_USER]'
+$SqlAdminPassword = '[SQL_PASSWORD]'
+$LicenseFilePath = '[LICENSE_FILE]'
+      ]]>
+      </ScriptMap>
+    </ScriptMaps>
+  </Configuration>
+  <Configuration topology="XM-CM-CD" version="9.0 Update 2" wrapper="PSTemplates\blank.ps1" scriptmaps="GLOBAL|INSTALL|UNINSTALL">
+    <File type="data" name="Sitecore 9.0.2 rev. 180604 (OnPrem)_cm.scwdp.zip" />
+    <File type="data" name="Sitecore 9.0.2 rev. 180604 (OnPrem)_cd.scwdp.zip" />
+    <File type="config" name="sitecore-solr.json">
+      <ScriptMaps>
+        <ScriptMap location="INSTALL">
+          <![CDATA[
+    $solrParams = @{
+    Path = "$PSScriptRoot\sitecore-solr.json"
+    SolrUrl = $SolrUrl
+    SolrRoot = $SolrRoot
+    SolrService = $SolrService
+    CorePrefix = $Prefix
+    }
+    Install-SitecoreConfiguration @solrParams
+        ]]>
+        </ScriptMap>
+        <ScriptMap location="UNINSTALL">
+          <![CDATA[
+    $solrParams = @{
+    Path = ".\remove-sitecore-solr-cores.json"
+    SolrUrl = $SolrUrl
+    SolrRoot = $SolrRoot
+    CorePrefix = $Prefix
+    }
+    try{
+	    Install-SitecoreConfiguration @solrParams
+    }
+    catch{
+	    $error = $_.Exception
+	
+	    #If we are failing because it has already been unloaded, then we can proceed
+	    if($error.Message.Contains("Cannot unload non-existent core")){
+		    Write-Warning -Message ("Core is not found. May have already been uninstalled. Proceeding to folders." | Out-String)
+	    }
+	    else{
+		    throw $error;
+	    }
+    }
+    #remove Sitecore Solr folders
+    $solrParams = @{
+    Path = ".\remove-sitecore-solr-folders.json"
+    SolrUrl = $SolrUrl
+    SolrRoot = $SolrRoot
+    CorePrefix = $Prefix
+    }
+    Install-SitecoreConfiguration @solrParams
+    ]]>
+        </ScriptMap>
+      </ScriptMaps>
+    </File>
+    <File type="config" name="sitecore-XM1-cm.json">
+      <FieldMaps>
+        <Field name="cm_sitename" type="text" map="CM_SITENAME" label="CM Site Name" description="The Name of the CM Website"/>
+      </FieldMaps>
+      <ScriptMaps>
+        <ScriptMap location="INSTALL">
+          <![CDATA[
+    $sitecore_cm_Params = @{
+    Path = "$PSScriptRoot\sitecore-XM1-cm.json"
+    Package = "$PSScriptRoot\Sitecore 9.0.2 rev. 180604 (OnPrem)_cm.scwdp.zip"
+    LicenseFile = $LicenseFilePath
+    SqlDbPrefix = $Prefix
+    SolrCorePrefix = $Prefix
+    SolrUrl = $SolrUrl
+    SiteName = '[CM_SITENAME]'
+    SqlServer = $SqlServer
+    SqlAdminPassword = $SqlAdminPassword
+    SqlAdminUser = $SqlAdminUser
+    }
+    Install-SitecoreConfiguration @sitecore_cm_Params
+        ]]>
+        </ScriptMap>
+        <ScriptMap location="UNINSTALL">
+          <![CDATA[
+           
+     $sitecoreParams = @{
+        Path = ".\remove-sitecore-XM.json"
+        SqlDbPrefix = $Prefix
+        SiteName = '[CM_SITENAME]'
+        SqlServer = $SqlServer
+        SqlAdminPassword = $SqlAdminPassword
+        SqlAdminUser = $SqlAdminUser
+        }
+        Install-SitecoreConfiguration @sitecoreParams
+          
+          ]]>
+        </ScriptMap>
+      </ScriptMaps>
+    </File>
+    <File type="config" name="sitecore-XM1-cd.json">
+      <FieldMaps>
+        <Field name="cd_sitename" type="text" map="CD_SITENAME" label="CD Site Name" description="The Name of the CD Website"/>
+      </FieldMaps>
+      <ScriptMaps>
+        <ScriptMap location="INSTALL">
+          <![CDATA[
+    $sitecore_cd_Params = @{
+    Path = "$PSScriptRoot\sitecore-XM1-cd.json"
+    Package = "$PSScriptRoot\Sitecore 9.0.2 rev. 180604 (OnPrem)_cd.scwdp.zip"
+    LicenseFile = $LicenseFilePath
+    SqlDbPrefix = $Prefix
+    SolrCorePrefix = $Prefix
+    SolrUrl = $SolrUrl
+    SiteName = '[CD_SITENAME]'
+    SqlServer = $SqlServer
+    }
+    Install-SitecoreConfiguration @sitecore_cd_Params
+        ]]>
+        </ScriptMap>
+        <ScriptMap location="UNINSTALL">
+          <![CDATA[
+           
+     $sitecoreParams = @{
+        Path = ".\remove-sitecore-XM-cd.json"
+        SiteName = '[CD_SITENAME]'
+        }
+        Install-SitecoreConfiguration @sitecoreParams
+          
+          ]]>
+        </ScriptMap>
+      </ScriptMaps>
+    </File>
+    <ScriptMaps>
+      <ScriptMap location="GLOBAL">
+        <![CDATA[
+$Prefix = '[PREFIX]'
+$PSScriptRoot = '[DATA_FOLDER]'
+$SolrUrl = '[SOLR_URL]'
+$SolrRoot = '[SOLR_ROOT]'
+$SolrService = '[SOLR_SERVICE]'
+$SqlServer = '[SQL_SERVER]'
+$SqlAdminUser = '[SQL_USER]'
+$SqlAdminPassword = '[SQL_PASSWORD]'
+$LicenseFilePath = '[LICENSE_FILE]'
+      ]]>
+      </ScriptMap>
+    </ScriptMaps>
+  </Configuration>
+	<Configuration topology="XP0" version="9.0 Update 2" wrapper="PSTemplates\blank.ps1" scriptmaps="GLOBAL|INSTALL|UNINSTALL">
+    <File type="data" name="Sitecore 9.0.2 rev. 180604 (OnPrem)_single.scwdp.zip" />
+    <File type="data" name="Sitecore 9.0.2 rev. 180604 (OnPrem)_xp0xconnect.scwdp.zip" />
+    <File type="config" name="xconnect-createcert.json">
+      <ScriptMaps>
+        <ScriptMap location="INSTALL">
+          <![CDATA[
+    $certParams = @{
+      Path = "$PSScriptRoot\xconnect-createcert.json"
+      CertificateName = $xConnectCertName 
+      }
+    Install-SitecoreConfiguration @certParams -Verbose
+        ]]>
+        </ScriptMap>
+      </ScriptMaps>
+    </File>
+    <File type="config" name="xconnect-solr.json">
+      <ScriptMaps>
+        <ScriptMap location="INSTALL">
+          <![CDATA[
+   $solrParams = @{
+Path = "$PSScriptRoot\xconnect-solr.json"
+SolrUrl = $SolrUrl
+SolrRoot = $SolrRoot
+SolrService = $SolrService
+CorePrefix = $Prefix
+}
+Install-SitecoreConfiguration @solrParams
+        ]]>
+        </ScriptMap>
+        <ScriptMap location="UNINSTALL">
+          <![CDATA[
+   
+$solrParams = @{
+Path = ".\remove-xconnect-solr-cores.json"
+SolrUrl = $SolrUrl
+SolrRoot = $SolrRoot
+CorePrefix = $Prefix
+}
+try{
+	Install-SitecoreConfiguration @solrParams
+}
+catch{
+	$error = $_.Exception
+	
+	#If we are failing because it has already been unloaded, then we can proceed
+	if($error.Message.Contains("Cannot unload non-existent core")){
+		Write-Warning -Message ("Core is not found. May have already been uninstalled." | Out-String)
+	}
+	else{
+		throw $error;
+	}
+}
+
+$solrParams = @{
+Path = ".\remove-xconnect-solr-folders.json"
+SolrRoot = $SolrRoot
+CorePrefix = $Prefix
+}
+Install-SitecoreConfiguration @solrParams
+
+    ]]>
+        </ScriptMap>
+      </ScriptMaps>
+    </File>
+    <File type="config" name="sitecore-solr.json">
+      <ScriptMaps>
+        <ScriptMap location="INSTALL">
+          <![CDATA[
+    $solrParams = @{
+    Path = "$PSScriptRoot\sitecore-solr.json"
+    SolrUrl = $SolrUrl
+    SolrRoot = $SolrRoot
+    SolrService = $SolrService
+    CorePrefix = $Prefix
+    }
+    Install-SitecoreConfiguration @solrParams
+        ]]>
+        </ScriptMap>
+        <ScriptMap location="UNINSTALL">
+          <![CDATA[
+   
+#remove solr cores for sitecore
+$solrParams = @{
+Path = ".\remove-sitecore-solr-cores.json"
+SolrUrl = $SolrUrl
+SolrRoot = $SolrRoot
+CorePrefix = $Prefix
+}
+try{
+	Install-SitecoreConfiguration @solrParams
+}
+catch{
+	$error = $_.Exception
+	
+	#If we are failing because it has already been unloaded, then we can proceed
+	if($error.Message.Contains("Cannot unload non-existent core")){
+		Write-Warning -Message ("Core is not found. May have already been uninstalled. Proceeding to folders." | Out-String)
+	}
+	else{
+		throw $error;
+	}
+}
+#remove Sitecore Solr folders
+$solrParams = @{
+Path = ".\remove-sitecore-solr-folders.json"
+SolrRoot = $SolrRoot
+CorePrefix = $Prefix
+}
+Install-SitecoreConfiguration @solrParams
+
+    ]]>
+        </ScriptMap>
+      </ScriptMaps>
+    </File>
+    <File type="config" name="xconnect-xp0.json">
+      <FieldMaps>
+        <Field name="xconnectsitename" type="text" map="XCONNECT_SITE" label="X Connect Site Name" description="The Name of the xConnect Website"/>
+      </FieldMaps>
+      <ScriptMaps>
+        <ScriptMap location="INSTALL">
+          <![CDATA[
+  $xconnectParams = @{
+  Path = "$PSScriptRoot\xconnect-xp0.json"
+  Package = "$PSScriptRoot\Sitecore 9.0.2 rev. 180604 (OnPrem)_xp0xconnect.scwdp.zip"
+  LicenseFile = $LicenseFilePath
+  Sitename = $xConnectSiteName
+  XConnectCert = $xConnectCertName 
+  SqlDbPrefix = $Prefix
+  SqlServer = $SqlServer
+  SqlAdminUser = $SqlAdminUser
+  SqlAdminPassword = $SqlAdminPassword
+  SolrCorePrefix = $Prefix
+  SolrURL = $SolrUrl
+  }
+  Install-SitecoreConfiguration @xconnectParams
+        ]]>
+        </ScriptMap>
+        <ScriptMap location="UNINSTALL">
+          <![CDATA[
+   $xconnectParams = @{
+Path = ".\remove-xconnect-xp0.json"
+SiteName = $xConnectSiteName
+SqlDbPrefix = $Prefix
+SqlServer = $SqlServer
+SqlAdminUser = $SqlAdminUser
+SqlAdminPassword = $SqlAdminPassword
+}
+
+Install-SitecoreConfiguration @xconnectParams
+    ]]>
+        </ScriptMap>
+      </ScriptMaps>
+    </File>
+    <File type="config" name="sitecore-XP0.json">
+      <FieldMaps>
+        <Field name="sitename" type="text" map="SITENAME" label="Site Name" description="The Name of the Website"/>
+      </FieldMaps>
+      <ScriptMaps>
+        <ScriptMap location="INSTALL">
+          <![CDATA[
+  $sitecoreParams = @{
+  Path = "$PSScriptRoot\sitecore-XP0.json"
+  Package = "$PSScriptRoot\Sitecore 9.0.2 rev. 180604 (OnPrem)_single.scwdp.zip"
+  LicenseFile = $LicenseFilePath
+  Sitename = '[SITENAME]'
+  XConnectCert = $xConnectCertName 
+  SqlDbPrefix = $Prefix
+  SqlServer = $SqlServer
+  SqlAdminUser = $SqlAdminUser
+  SqlAdminPassword = $SqlAdminPassword
+  SolrCorePrefix = $Prefix
+  SolrURL = $SolrUrl
+  XConnectCollectionService = "https://$xConnectSiteName"
+  }
+  Install-SitecoreConfiguration @$sitecoreParams
+        ]]>
+        </ScriptMap>
+        <ScriptMap location="UNINSTALL">
+          <![CDATA[
+   $sitecoreParams = @{
+Path = ".\remove-sitecore-xp0.json"
+SqlDbPrefix = $Prefix
+SqlServer = $SqlServer
+SqlAdminUser = $SqlAdminUser
+SqlAdminPassword = $SqlAdminPassword
+SiteName = '[SITENAME]'
+}
+Install-SitecoreConfiguration @sitecoreParams
+    ]]>
+        </ScriptMap>
+      </ScriptMaps>
+    </File>
+    <ScriptMaps>
+      <ScriptMap location="GLOBAL">
+        <![CDATA[
+$Prefix = '[PREFIX]'
+$PSScriptRoot = '[DATA_FOLDER]'
+$SolrUrl = '[SOLR_URL]'
+$SolrRoot = '[SOLR_ROOT]'
+$SolrService = '[SOLR_SERVICE]'
+$SqlServer = '[SQL_SERVER]'
+$SqlAdminUser = '[SQL_USER]'
+$SqlAdminPassword = '[SQL_PASSWORD]'
+$LicenseFilePath = '[LICENSE_FILE]'
+$xConnectCertName = "$Prefix.xconnect_client"
+$xConnectSiteName = '[XCONNECT_SITE]'
+      ]]>
+      </ScriptMap>
+    </ScriptMaps>
+  </Configuration>
 </Configurations>

--- a/SIFLess/SIFLess/Forms/MainForm.cs
+++ b/SIFLess/SIFLess/Forms/MainForm.cs
@@ -181,7 +181,7 @@ namespace SIFLess.Forms
             {
                 if (control is StringControl scControl)
                 {
-                    values.Add(scControl.Field, scControl.Value);
+                    values.Add(scControl.FieldMap, scControl.Value);
                 }
             }
 

--- a/SIFLess/SIFLess/SIFLess.csproj
+++ b/SIFLess/SIFLess/SIFLess.csproj
@@ -47,8 +47,8 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Management" />
     <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>C:\Program Files (x86)\Reference Assemblies\Microsoft\WindowsPowerShell\3.0\System.Management.Automation.dll</HintPath>
+      <HintPath>..\packages\System.Management.Automation.dll.10.0.10586.0\lib\net40\System.Management.Automation.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System.ServiceProcess" />
     <Reference Include="System.Web" />
@@ -260,6 +260,7 @@
   <ItemGroup>
     <Content Include="Data\ConfigurationManifest.xml">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </Content>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/SIFLess/SIFLess/packages.config
+++ b/SIFLess/SIFLess/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Newtonsoft.Json" version="11.0.1" targetFramework="net462" />
+  <package id="System.Management.Automation.dll" version="10.0.10586.0" targetFramework="net462" />
   <package id="Unity" version="5.8.5" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
Added update 2 to config and manifest

SiteName was not merged correctly to the ps1 parameters, changed to use FieldMap instead of Field

Could not compile due to wrong version of System.Management.Automation, added correct version to packages.

New parameter "SolrZookeeperUrl" has been introduced in update 2. I have not done anything to support this.

Only tested with XM-CM topology