### PR TITLE
Fix the solr check for 9.0.x installs to use the right xml variable

### DIFF
--- a/SIFLess/SIFLess/Data/Sitecore 9.0.0.xml
+++ b/SIFLess/SIFLess/Data/Sitecore 9.0.0.xml
@@ -81,7 +81,7 @@
     #Check Solr Version
     $solrVerClient = (New-Object System.Net.WebClient)
     [xml]$solrAdminResp = $solrVerClient.DownloadString("$SolrUrl/admin/info/system") 
-    $solrVersion =  select-xml -xml $xml -xpath "//str[@name='solr-spec-version']/text()" | % { $_.Node.Value }
+    $solrVersion =  select-xml -xml $solrAdminResp -xpath "//str[@name='solr-spec-version']/text()" | % { $_.Node.Value }
     
     if($solrVersion -ne "6.6.2" -and $solrVersion -ne "6.6.3"){
       throw "Invalid solr version '$solrVersion'."

--- a/SIFLess/SIFLess/Data/Sitecore 9.0.1.xml
+++ b/SIFLess/SIFLess/Data/Sitecore 9.0.1.xml
@@ -238,7 +238,7 @@ $SecurePassword = 'Sitecor3SecureP4ssword!'
     #Check Solr Version
     $solrVerClient = (New-Object System.Net.WebClient)
     [xml]$solrAdminResp = $solrVerClient.DownloadString("$SolrUrl/admin/info/system") 
-    $solrVersion =  select-xml -xml $xml -xpath "//str[@name='solr-spec-version']/text()" | % { $_.Node.Value }
+    $solrVersion =  select-xml -xml $solrAdminResp -xpath "//str[@name='solr-spec-version']/text()" | % { $_.Node.Value }
     
     if($solrVersion -ne "6.6.2" -and $solrVersion -ne "6.6.3"){
       throw "Invalid solr version '$solrVersion'."

--- a/SIFLess/SIFLess/Data/Sitecore 9.0.2.xml
+++ b/SIFLess/SIFLess/Data/Sitecore 9.0.2.xml
@@ -238,7 +238,7 @@ $SecurePassword = 'Sitecor3SecureP4ssword!'
     #Check Solr Version
     $solrVerClient = (New-Object System.Net.WebClient)
     [xml]$solrAdminResp = $solrVerClient.DownloadString("$SolrUrl/admin/info/system") 
-    $solrVersion =  select-xml -xml $xml -xpath "//str[@name='solr-spec-version']/text()" | % { $_.Node.Value }
+    $solrVersion =  select-xml -xml $solrAdminResp -xpath "//str[@name='solr-spec-version']/text()" | % { $_.Node.Value }
     
     if($solrVersion -ne "6.6.2" -and $solrVersion -ne "6.6.3"){
       throw "Invalid solr version '$solrVersion'."


### PR DESCRIPTION
The variable name for the XML was wrong. Fixed in all 9.0.x template files.